### PR TITLE
Add biblionumber to coce query

### DIFF
--- a/plugins/Carrousel.pm
+++ b/plugins/Carrousel.pm
@@ -313,6 +313,7 @@ sub retrieveUrlFromCoceJson {
 
 sub getUrlFromExternalSources {
     my $isbn = shift;
+    my $biblionumber = shift;
 
     # les clefs sont les systempreferences du même nom
     my $es = {};
@@ -322,6 +323,7 @@ sub getUrlFromExternalSources {
         'retrieval' => \&retrieveUrlFromCoceJson,
         'url' => C4::Context->preference('CoceHost').'/cover'
                 ."?id=$isbn"
+                ."&bn=$biblionumber"
                 .'&provider='.join(',', C4::Context->preference('CoceProviders'))
                 .'&thumbnail=1',
     };
@@ -407,7 +409,7 @@ sub getThumbnailUrl
         my $isbn = GetNormalizedISBN( $field->subfield('a') );
         next if ! $isbn;
 
-        return getUrlFromExternalSources($isbn);
+        return getUrlFromExternalSources($isbn, $biblionumber);
     }
 
     return;


### PR DESCRIPTION
Pour récupérer les imagettes de l'OPAC, Coce doit recevoir le _biblionumber_ de quelque part, information qui n'est pas dérivable du ISBN.

Cette patch fourni l'information sous forme d'un paramètre HTTP supplémentaire dans l'URL de requête vers Coce: bn