### PR TITLE
Carrousel : add script to generate via command line

### DIFF
--- a/plugins/Koha/Plugin/Carrousel/cron/generate.pl
+++ b/plugins/Koha/Plugin/Carrousel/cron/generate.pl
@@ -1,0 +1,13 @@
+#!/usr/bin/perl
+
+use Modern::Perl;
+
+use Koha::Plugin::Carrousel;
+use Koha::Virtualshelves;
+
+my $p = Koha::Plugin::Carrousel->new( { enable_plugins => 1 } );
+
+@Koha::Plugin::Carrousel::shelves =
+  Koha::Virtualshelves->search( undef, { order_by => { -asc => 'shelfname' } } );
+$p->orderShelves();
+$p->generateCarrousels();


### PR DESCRIPTION
Via command line (mostly for nighty cron) :
Do the same as in interface run the plugin and generate carrousels.