### PR TITLE
Carrousel : typo in css

### DIFF
--- a/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
+++ b/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
@@ -91,7 +91,7 @@
     right: 0;
 }
 
-usel-control,
+.carousel-control,
 .carousel-caption{
     background-color : #[%bgColor%];
     z-index:1000;


### PR DESCRIPTION
Trivial typo in Carrousel CSS : 
usel-control, => .carousel-control,