### PR TITLE
Carrousel : add install method

### DIFF
--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -623,6 +623,14 @@ sub configure {
     }
 }
 
+sub install {
+    my ( $self, $args ) = @_;
+
+    # Nothing actually
+
+    return 1;
+}
+
 sub upgrade {
     my ( $self, $args ) = @_;
     my $database_version = $self->retrieve_data('__INSTALLED_VERSION__') || $VERSION;


### PR DESCRIPTION
Allows install from command line with misc/devel/install_plugins.pl

Otherwise plugin is installed disabled.

This method may be useful in the future.