### PR TITLE
carrousel - fixup cam12471 - Changer la version du carrousel pour un …

### DIFF
--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -41,9 +41,9 @@ use C4::Reports::Guided;
 use Koha::Uploader;
 use Koha::News;
 
-our $VERSION = 3.5.1;
+our $VERSION = 3.6;
 our $metadata = {
-    name            => 'Carrousel 3.5.1',
+    name            => 'Carrousel 3.6',
     author          => 'Mehdi Hamidi, Maryse Simard, Brandon Jimenez',
     description     => 'Generates a carrousel from available data sources (lists, reports or collections).',
     date_authored   => '2016-05-27',


### PR DESCRIPTION
…bon affichage

On change la version du carrousel de 3.5.1 à 3.6 car la première option
empêche le bon affichage de la version du carrousel ou nécessite
l'utisaltion d'un module que Koha n'a pas de base.