### PR TITLE
carrousel - cam13472 - La version 'A defilement' ne clique plus en pe…

### DIFF
--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -41,13 +41,13 @@ use C4::Reports::Guided;
 use Koha::Uploader;
 use Koha::News;
 
-our $VERSION = 3.7;
+our $VERSION = 3.8;
 our $metadata = {
-    name            => 'Carrousel 3.7',
-    author          => 'Mehdi Hamidi, Maryse Simard, Brandon Jimenez',
+    name            => 'Carrousel 3.8',
+    author          => 'Mehdi Hamidi, Maryse Simard, Brandon Jimenez, Alexis Ripetti',
     description     => 'Generates a carrousel from available data sources (lists, reports or collections).',
     date_authored   => '2016-05-27',
-    date_updated    => '2021-03-02',
+    date_updated    => '2021-06-17',
     minimum_version => '3.20',
     maximum_version => undef,
     version         => $VERSION,

--- a/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
+++ b/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
@@ -246,9 +246,9 @@ document.addEventListener('DOMContentLoaded', function() {
             [% IF carrousel.autorotate %]
                 setInterval(
                     function() {
-                        $("#carrousel-[% loop.index %] .controls button")
-                            [% IF !autoRotateDirection || autoRotateDirection == "left" %].eq(0)[% ELSIF autoRotateDirection == "right" %].eq(1)[% END %]
-                            .click();
+                        let buttonLeft = $("#carrousel-[% loop.index %] .controls button")[0];
+                        let buttonRight = $("#carrousel-[% loop.index %] .controls button")[1];
+                        [% IF !autoRotateDirection || autoRotateDirection == "left" %]Right(buttonLeft)[% ELSIF autoRotateDirection == "right" %]Left(buttonRight)[% END %];
                     }, [% autoRotateDelay || 1500 %]
                 );
             [% END %]


### PR DESCRIPTION
…rmanence

La version 'A defilement' du carrouel utilisait la fonction click() pour
fonctionner. Cela ne permettait pas de naviguer dans les menus
déroulants car le carrousel reprenait le focus.