### PR TITLE
pdftocover - Faire fonctionner le plugin quand le package poppler-utils est présent

### DIFF
--- a/plugins/Koha/Plugin/PDFtoCover.pm
+++ b/plugins/Koha/Plugin/PDFtoCover.pm
@@ -63,8 +63,8 @@ sub tool {
     my $lock_path = File::Spec->catdir( File::Spec->rootdir(), "tmp", ".Koha.PDFtoCover.lock" );
     my $lock = (-e $lock_path) ? 1 : 0;
 
-    my $poppler = "/usr/bin/poppler-utils";
-    unless ( -e $poppler ) {
+    my $poppler = "/usr/bin/pdftocairo";
+    unless (-e $poppler){
         $self->missingModule();
     }
     elsif ( $op && $op eq 'valide' ) {


### PR DESCRIPTION
cam15119 - Modification du fichier PDFtoCover.pm , afin que le plugin
fonctionne lorsque poppler-utils est installé