### PR TITLE
pdftocover - cam15084 - PDFtoCover fonctionne sur GoogleChrome

### DIFF
--- a/plugins/Koha/Plugin/PDFtoCover/step_1.tt
+++ b/plugins/Koha/Plugin/PDFtoCover/step_1.tt
@@ -20,14 +20,14 @@
         <label class="filterDescription"><p>Number of records to process: <span id="to_process">[% pdf %]</span></p></label>
         <hr>
 
-        <form method="get" id="formTraitement">
+        <form onbsubmit="launchGenerate()" method="get" id="formTraitement">
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
             <input type="hidden" id="op" name="op" value="valide"/>
 
-            <button id="launch" type="submit" class="btn btn-default" onclick="launchGenerate()">Create thumbnails</button>
+            <button id="launch" type="submit" class="btn btn-default">Create thumbnails</button>
         </form>
 
         <p id="progression">&nbsp;</p>

--- a/plugins/Koha/Plugin/PDFtoCover/step_1_fr-CA.tt
+++ b/plugins/Koha/Plugin/PDFtoCover/step_1_fr-CA.tt
@@ -20,14 +20,14 @@
         <label class="filterDescription"><p>Nombre de notices à traiter : <span id="to_process">[% pdf %]</span></p></label>
         <hr>
 
-        <form method="get" id="formTraitement">
+        <form onsubmit="launchGenerate()" method="get" id="formTraitement">
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
             <input type="hidden" id="op" name="op" value="valide"/>
 
-            <button id="launch" type="submit" class="btn btn-default" onclick="launchGenerate()">Générer les vignettes</button>
+            <button id="launch" type="submit" class="btn btn-default">Générer les vignettes</button>
         </form>
 
         <p id="progression">&nbsp;</p>

--- a/plugins/Koha/Plugin/PDFtoCover/step_1_fr.tt
+++ b/plugins/Koha/Plugin/PDFtoCover/step_1_fr.tt
@@ -20,14 +20,14 @@
         <label class="filterDescription"><p>Nombre de notices à traiter : <span id="to_process">[% pdf %]</span></p></label>
         <hr>
 
-        <form method="get" id="formTraitement">
+        <form onsubmit="launchGenerate()" method="get" id="formTraitement">
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
             <input type="hidden" id="op" name="op" value="valide"/>
 
-            <button id="launch" type="submit" class="btn btn-default" onclick="launchGenerate()">Générer les vignettes</button>
+            <button id="launch" type="submit" class="btn btn-default">Générer les vignettes</button>
         </form>
 
         <p id="progression">&nbsp;</p>


### PR DESCRIPTION
Le plugin PDFtoCover fonctionne maintenant sur les navigateurs
GoogleChrome et Firefox