### PR TITLE
carrousel - cam17404 - donner accès au config quand liste est supprimée

### DIFF
--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -52,9 +52,9 @@ BEGIN {
     $module->import;
 }
 
-our $VERSION = "4.0.3";
+our $VERSION = "4.0.4";
 our $metadata = {
-    name            => 'Carrousel 4.0.3',
+    name            => 'Carrousel 4.0.4',
     author          => 'Mehdi Hamidi, Maryse Simard, Brandon Jimenez, Alexis Ripetti, Salman Ali',
     description     => 'Generates a carrousel from available data sources (lists, reports or collections).',
     date_authored   => '2016-05-27',

--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -249,7 +249,8 @@ sub getEnabledCarrousels {
         $carrousel->{name} = $self->getDisplayName($carrousel->{module}, $carrousel->{id});
         my $branchcode;
         if ($carrousel->{module} eq "lists") {
-            my $borrowernumber = Koha::Virtualshelves->find($carrousel->{id})->owner;
+            my $shelf = Koha::Virtualshelves->find($carrousel->{id});
+            my $borrowernumber = $shelf->owner if defined $shelf;
             if (C4::Context->preference("IndependentBranches")) {
                 my $patron = Koha::Patrons->find($borrowernumber);
                 $branchcode = $patron->branchcode if defined $patron;


### PR DESCRIPTION
Fix l'erreur 500 sur la page de config lorsque la liste utilisée par le carrousel est supprimée.