### PR TITLE
cam18416: Carrousel and accessibility #82 

### DIFF
--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -316,7 +316,24 @@ sub generateCarrousels{
                 { binmode => ':utf8' }
             ) || warn "Unable to generate Carrousel, " . $tt->error();
 
-            $self->insertIntoPref($data, $branchcode);
+            $self->insertIntoPref($data, $branchcode, "en");
+            $self->generateJSONFile($carrousels) if ($self->retrieve_data('generateJSON'));
+
+            $tt->process(
+                'Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt',
+                {
+                    carrousels => $carrousels,
+                    bgColor  => $self->retrieve_data('bgColor'),
+                    txtColor => $self->retrieve_data('txtColor'),
+                    autoRotateDirection => $self->retrieve_data('autoRotateDirection'),
+                    autoRotateDelay => $self->retrieve_data('autoRotateDelay'),
+                    ENCODING => 'utf8',
+                },
+                \$data,
+                { binmode => ':utf8' }
+            ) || warn "Unable to generate Carrousel, " . $tt->error();
+
+            $self->insertIntoPref($data, $branchcode, "fr-CA");
             $self->generateJSONFile($carrousels) if ($self->retrieve_data('generateJSON'));
         }
     } else {
@@ -336,7 +353,25 @@ sub generateCarrousels{
             { binmode => ':utf8' }
         ) || warn "Unable to generate Carrousel, " . $tt->error();
 
-        $self->insertIntoPref($data, undef);
+        $self->insertIntoPref($data, undef, "en");
+        $self->generateJSONFile($carrousels) if ($self->retrieve_data('generateJSON'));
+        
+        $data = "";        
+        $tt->process(
+            'Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt',
+            {
+                carrousels => $carrousels,
+                bgColor  => $self->retrieve_data('bgColor'),
+                txtColor => $self->retrieve_data('txtColor'),
+                autoRotateDirection => $self->retrieve_data('autoRotateDirection'),
+                autoRotateDelay => $self->retrieve_data('autoRotateDelay'),
+                ENCODING => 'utf8',
+            },
+            \$data,
+            { binmode => ':utf8' }
+        ) || warn "Unable to generate Carrousel, " . $tt->error();
+
+        $self->insertIntoPref($data, undef, "fr-CA");
         $self->generateJSONFile($carrousels) if ($self->retrieve_data('generateJSON'));
     }
 }
@@ -450,8 +485,8 @@ sub getKohaVersion {
     return $kohaversion;
 }
 
-sub insertIntoPref{
-    my ( $self, $data, $branchcode) = @_;
+sub insertIntoPref {
+    my ( $self, $data, $branchcode, $lang) = @_;
 
     # we select the current version of Koha
     my $kohaversion = getKohaVersion();
@@ -546,7 +581,7 @@ sub insertIntoPref{
         my $location = 'OpacMainUserBlock';
         my $published_on = dt_from_string()->ymd();
         my $code = undef;
-        my $lang = "default";
+        #my $lang = "fr-CA";
         my $expirationdate = undef;
         my $number = undef;
         my $title = 'OpacMainUserBlock_Carrousel';
@@ -972,3 +1007,4 @@ sub retrieve_template {
 }
 
 1;
+

--- a/plugins/Koha/Plugin/Carrousel.pm
+++ b/plugins/Koha/Plugin/Carrousel.pm
@@ -52,9 +52,9 @@ BEGIN {
     $module->import;
 }
 
-our $VERSION = "4.0.5";
+our $VERSION = "4.1.0";
 our $metadata = {
-    name            => 'Carrousel 4.0.5',
+    name            => 'Carrousel 4.1.0',
     author          => 'Mehdi Hamidi, Maryse Simard, Brandon Jimenez, Alexis Ripetti, Salman Ali',
     description     => 'Generates a carrousel from available data sources (lists, reports or collections).',
     date_authored   => '2016-05-27',

--- a/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
+++ b/plugins/Koha/Plugin/Carrousel/opac-carrousel.tt
@@ -8,8 +8,8 @@
             <p class="special-title">[% carrousel.title || carrousel.name %]</p>
             <div class="loadingDiv"></div>
             <div id="carrousel-[% loop.index %]" class="carrousel">
-                <a class="left carousel-control" aria-label="next" tabindex="0">&lsaquo;</a>
-                <a class="right carousel-control" aria-label="previous" tabindex="0">&rsaquo;</a>
+                <a class="left carousel-control" aria-label="previous" tabindex="0">&lsaquo;</a>
+                <a class="right carousel-control" aria-label="next" tabindex="0">&rsaquo;</a>
                 [% FOREACH item IN carrousel.documents %]
                     <a href="/cgi-bin/koha/opac-detail.pl?biblionumber=[% item.biblionumber %]" title="[% item.title %]"><img class="cloudcarousel" src="[% item.url %]" alt="[% item.title %]" ></a>
                 [% END %]

--- a/plugins/Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt
+++ b/plugins/Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt
@@ -8,8 +8,8 @@
             <p class="special-title">[% carrousel.title || carrousel.name %]</p>
             <div class="loadingDiv"></div>
             <div id="carrousel-[% loop.index %]" class="carrousel">
-                <a class="left carousel-control" aria-label="suivant" tabindex="0">&lsaquo;</a>
-                <a class="right carousel-control" aria-label="précédent" tabindex="0">&rsaquo;</a>
+                <a class="left carousel-control" aria-label="précédent" tabindex="0">&lsaquo;</a>
+                <a class="right carousel-control" aria-label="suivant" tabindex="0">&rsaquo;</a>
                 [% FOREACH item IN carrousel.documents %]
                     <a href="/cgi-bin/koha/opac-detail.pl?biblionumber=[% item.biblionumber %]" title="[% item.title %]"><img class="cloudcarousel" src="[% item.url %]" alt="[% item.title %]" ></a>
                 [% END %]

--- a/plugins/Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt
+++ b/plugins/Koha/Plugin/Carrousel/opac-carrousel_fr-CA.tt
@@ -8,8 +8,8 @@
             <p class="special-title">[% carrousel.title || carrousel.name %]</p>
             <div class="loadingDiv"></div>
             <div id="carrousel-[% loop.index %]" class="carrousel">
-                <a class="left carousel-control" aria-label="next" tabindex="0">&lsaquo;</a>
-                <a class="right carousel-control" aria-label="previous" tabindex="0">&rsaquo;</a>
+                <a class="left carousel-control" aria-label="suivant" tabindex="0">&lsaquo;</a>
+                <a class="right carousel-control" aria-label="précédent" tabindex="0">&rsaquo;</a>
                 [% FOREACH item IN carrousel.documents %]
                     <a href="/cgi-bin/koha/opac-detail.pl?biblionumber=[% item.biblionumber %]" title="[% item.title %]"><img class="cloudcarousel" src="[% item.url %]" alt="[% item.title %]" ></a>
                 [% END %]
@@ -33,8 +33,8 @@
                     </div>
                 </div>
                 <div class="controls">
-                    <button class="[% carrousel.title || carrousel.name %]" aria-label="previous" style="float:left" onclick="Right(this)" type="button">&lt;</button>
-                    <button class="[% carrousel.title || carrousel.name %]" aria-label="next" style="float:right" onclick="Left(this)" type="button">&gt;</button>
+                    <button class="[% carrousel.title || carrousel.name %]" aria-label="précédent" style="float:left" onclick="Right(this)" type="button">&lt;</button>
+                    <button class="[% carrousel.title || carrousel.name %]" aria-label="suivant" style="float:right" onclick="Left(this)" type="button">&gt;</button>
                 </div>
             [% END %]
         </div>
@@ -401,6 +401,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 );
             });
+
         [% ELSE %]
             [% IF carrousel.autorotate %]
                 setInterval(
@@ -470,4 +471,5 @@ window.addEventListener('load', function() {
 });
 */
 </script>
+
 


### PR DESCRIPTION
Dans Carrousel.pm:
J’ajoute un nouveau fichier qui serre pour la traduction (opac-carrousel_fr_CA). Je fais en sorte que quand on fait la générassions du  carrousel il change la version fr-CA et la version en(original). J’ajoute un paramètre au insertIntoPref(line 489). En fonctions de la lange qu’il reçoit en paramètre, il fait le changement dans la BD. (Pour le client ça devrait rien ne change)

Dans le opac-carrousel et opac-carrousel_fr_CA : le button "<" et ">" on peut les sélectionne avec tab. Si on utilise un Screen Reader on entend "previous" et "next" en fonctions de la lange choisi au lieu de "<" et ">".
Je remis le button "<" et ">" plus aux milieux et change la couleur pour qu’elle change en foncions de ce que le client choisi en configuration. La bordure change aussi en foncions de la couleur choisie.
J’aussi ajoute un focus pour les images quand on les sélections avec tab.